### PR TITLE
 Fix etykietę temperatury SMS, gdy skonfigurowane Fahrenheita

### DIFF
--- a/modules/sms/sms_send
+++ b/modules/sms/sms_send
@@ -8,6 +8,8 @@ nr=`sqlite3 -cmd ".timeout 2000" $dir/dbf/nettemp.db "SELECT tel FROM users WHER
 
 mkdir -p $dir/tmp/sms
 
+temp_scale=`sqlite3 -cmd ".timeout 2000" $dir/dbf/nettemp.db "SELECT temp_scale FROM settings"`
+
 check_alarm() {
 for line in `sqlite3 -cmd ".timeout 2000" $dir/dbf/nettemp.db "SELECT name,tmp,tmp_min,tmp_max,type FROM sensors WHERE alarm='on'"| sed 's/ /_/g'`; 
     do
@@ -18,7 +20,7 @@ for line in `sqlite3 -cmd ".timeout 2000" $dir/dbf/nettemp.db "SELECT name,tmp,t
 		tmp=`echo $line | awk 'BEGIN {FS="|"}{print $2}'`
 		tmp_min=`echo $line | awk 'BEGIN {FS="|"}{print $3}'`
 		tmp_max=`echo $line | awk 'BEGIN {FS="|"}{print $4}'`
-		type=$(echo $line | awk 'BEGIN {FS="|"}{print $5}' | sed 's/|/ /g' | sed 's/press/hPa/g' | sed 's/temp/C/g' | sed 's/humid/%/g' | sed 's/volt/V/g' | sed 's/amps/A/g' | sed 's/watt/W/g' | sed 's/water/m3/g' | sed 's/gas/m3/g' | sed 's/elec/kWh/g')
+		type=$(echo $line | awk 'BEGIN {FS="|"}{print $5}' | sed 's/|/ /g' | sed 's/press/hPa/g' | sed 's/temp/$temp_scale/g' | sed 's/humid/%/g' | sed 's/volt/V/g' | sed 's/amps/A/g' | sed 's/watt/W/g' | sed 's/water/m3/g' | sed 's/gas/m3/g' | sed 's/elec/kWh/g')
 		plik=/var/spool/sms/outgoing/sms-$name-$line2
 		sent=/var/spool/sms/sent/sms-$name-$line2
 		failed=/var/spool/sms/failed/sms-$name-$line2


### PR DESCRIPTION
**polski Tłumaczenie**

Kod prądu do wysyłania powiadomień SMS temperatury zawsze używa etykiety C dla temperatur nawet gdy nettemp jest skonfigurowany dla Fahrenheita. Zmiana ta usuwa etykietę skonfigurowanego ustawienia.

**English**

The current code for sending SMS temperature notifications always uses the C label for temperatures even when nettemp is configured for Fahrenheit. This change fixes the label for the configured setting.